### PR TITLE
Fix heap-buffer overflow in MOParser's loadFile:

### DIFF
--- a/POLocalizedString/MOParser.m
+++ b/POLocalizedString/MOParser.m
@@ -119,7 +119,7 @@ typedef struct _mo_position {
 		}
 		
 		// allocate or reallocate string buffer if necessary
-		newbufsize = MAX(256, MAX(translations[i].length, originals[i].length));
+		newbufsize = MAX(256, MAX(translations[i].length, originals[i].length)) + 1;
 		if(bufsize < newbufsize) {
             
 			bufsize = newbufsize;


### PR DESCRIPTION
Because `buf[translations[i].length]` and `buf[originals[i].length]` are set to `'\0'`, we must reserve one extra byte for the nul; .length is not quite big enough.

The issue was detected using Xcode's AddressSanitizer.